### PR TITLE
Update RepositoryMap for latest drivers to date

### DIFF
--- a/src/main/resources/RepositoryMap.xml
+++ b/src/main/resources/RepositoryMap.xml
@@ -4,82 +4,68 @@
         <driver id="internetexplorer">
             <version id="3.9.0">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>http://selenium-release.storage.googleapis.com/3.9/IEDriverServer_x64_3.9.0.zip</filelocation>
-                    <hash>c9f885b6a339f3f0039d670a23f998868f539e65</hash>
-                    <hashtype>sha1</hashtype>
+                    <filelocation>http://selenium-release.storage.googleapis.com/3.9.0/IEDriverServer_x64_3.9.0.zip</filelocation>
+                    <hash>5cff5e4d62b13876c0b2cd9b7bd4a2b3</hash>
+                    <hashtype>md5</hashtype>
                 </bitrate>
                 <bitrate thirtytwobit="true">
-                    <filelocation>http://selenium-release.storage.googleapis.com/3.9/IEDriverServer_Win32_3.9.0.zip</filelocation>
-                    <hash>dab42d7419599dd311d4fba424398fba2f20e883</hash>
-                    <hashtype>sha1</hashtype>
+                    <filelocation>http://selenium-release.storage.googleapis.com/3.9.0/IEDriverServer_Win32_3.9.0.zip</filelocation>
+                    <hash>c7d7743b24cb897c8565839cec22ca83</hash>
+                    <hashtype>md5</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="edge">
             <version id="5.16299">
                 <bitrate sixtyfourbit="true" thirtytwobit="true">
-                    <filelocation>https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe</filelocation>
-                    <hash>60c4b6d859ee868ba5aa29c1e5bfa892358e3f96</hash>
+                    <filelocation>https://download.microsoft.com/download/F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD/MicrosoftWebDriver.exe</filelocation>
+                    <hash>e53eecfb3fc02aebea34a39d9097b9d4fab669c8</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="googlechrome">
-            <version id="2.37">
+            <version id="2.43">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.37/chromedriver_win32.zip</filelocation>
-                    <hash>fe708aac4eeb919a4ce26cf4aa52a2dacc666a2f</hash>
-                    <hashtype>sha1</hashtype>
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.43/chromedriver_win32.zip</filelocation>
+                    <hash>d238c157263ec7f668e0ea045f29f1b7</hash>
+                    <hashtype>md5</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="operachromium">
-            <version id="2.35">
+            <version id="2.40">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.35/operadriver_win64.zip</filelocation>
-                    <hash>180a876f40dbc9734ebb81a3b6f2be35cadaf0cc</hash>
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.40/operadriver_win64.zip</filelocation>
+                    <hash>d8635bb0443cbed3a2a8cfc35b56bee4d79881d7</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
                 <bitrate thirtytwobit="true">
-                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.35/operadriver_win32.zip</filelocation>
-                    <hash>55d43156716d7d1021733c2825e99896fea73815</hash>
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.40/operadriver_win32.zip</filelocation>
+                    <hash>11cf931532f838c139ecaf838c180f493a9613d4</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="phantomjs">
-            <version id="1.9.8">
+            <version id="2.5.0">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip</filelocation>
-                    <hash>4531bd64df101a689ac7ac7f3e11bb7e77af8eff</hash>
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta2-windows.zip</filelocation>
+                    <hash>13d11d9ef7e0ba9c887e39f71e29a3b07c872e07</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="marionette">
-            <version id="0.20.0">
+            <version id="0.23.0">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-win64.zip</filelocation>
-                    <hash>e96a24cf4147d6571449bdd279be65a5e773ba4c</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-win64.zip</filelocation>
+                    <hash>23d3c5e30a5d646ef62eb184737d24451a1229f4</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
                 <bitrate thirtytwobit="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-win32.zip</filelocation>
-                    <hash>9aa5bbdc68acc93c244a7ba5111a3858d8cbc41d</hash>
-                    <hashtype>sha1</hashtype>
-                </bitrate>
-            </version>
-        </driver>
-        <driver id="firefox">
-            <version id="56.0.2">
-                <bitrate sixtyfourbit="true">
-                    <filelocation>https://www.firefox-usb.com/download/FirefoxPortable64-56.0.2.zip</filelocation>
-                    <hash>8b748fdce30c99f467718177ec56ede811953e53</hash>
-                    <hashtype>sha1</hashtype>
-                </bitrate>
-                <bitrate thirtytwobit="true">
-                    <filelocation>https://www.firefox-usb.com/download/FirefoxPortable32-56.0.2.zip</filelocation>
-                    <hash>423ef16181fdab526a5f53d3272a75acd4911838</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-win32.zip</filelocation>
+                    <hash>8feb0fe8655c6b67dd5afb714a50bdca810cbf7a</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -87,66 +73,52 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="2.37">
+            <version id="2.43">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip</filelocation>
-                    <hash>b8515d09bb2d533ca3b85174c85cac1e062d04c6</hash>
-                    <hashtype>sha1</hashtype>
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.43/chromedriver_linux64.zip</filelocation>
+                    <hash>1a67148288f4320e5125649f66e02962</hash>
+                    <hashtype>md5</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="operachromium">
-            <version id="2.35">
+            <version id="2.40">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.35/operadriver_linux64.zip</filelocation>
-                    <hash>f75845a7e37e4c1a58c61677a2d6766477a4ced2</hash>
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.40/operadriver_linux64.zip</filelocation>
+                    <hash>46a823d70ab56d45cc4f8ac012dea038437c525b</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="phantomjs">
-            <version id="1.9.8">
+            <version id="2.5.0">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2</filelocation>
-                    <hash>d29487b2701bcbe3c0a52bc176247ceda4d09d2d</hash>
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-linux-ubuntu-xenial-x86_64.tar.gz</filelocation>
+                    <hash>fe7f27da406058e811e316beecd3c66f8ac2202e</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
                 <bitrate thirtytwobit="true">
-                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-i686.tar.bz2</filelocation>
-                    <hash>efac5ae5b84a4b2b3fa845e8390fca39e6e637f2</hash>
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-linux-ubuntu-trusty-x86_64.tar.gz</filelocation>
+                    <hash>19ee3704f02d205bf2e401f2a30f5ec3e2e9bf36</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="marionette">
-            <version id="0.20.0">
+            <version id="0.23.0">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz</filelocation>
-                    <hash>e23a6ae18bec896afe00e445e0152fba9ed92007</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz</filelocation>
+                    <hash>7d387a162abc0baba91b56fa1258c3715263f67a</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
                 <bitrate thirtytwobit="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux32.tar.gz</filelocation>
-                    <hash>c80eb7a07ae3fe6eef2f52855007939c4b655a4c</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux32.tar.gz</filelocation>
+                    <hash>1cbc8c957a02978adc6edf6171d76c22566d3202</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
                 <bitrate arm="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-arm7hf.tar.gz</filelocation>
-                    <hash>2776db97a330c38bb426034d414a01c7bf19cc94</hash>
-                    <hashtype>sha1</hashtype>
-                </bitrate>
-            </version>
-        </driver>
-        <driver id="firefox">
-            <version id="56.0.2">
-                <bitrate sixtyfourbit="true">
-                    <filelocation>https://ftp.mozilla.org/pub/firefox/releases/56.0.2/linux-x86_64/en-US/firefox-56.0.2.tar.bz2</filelocation>
-                    <hash>2daf7f9e8dbc3e5c083b4eef923051cdca5fed3a</hash>
-                    <hashtype>sha1</hashtype>
-                </bitrate>
-                <bitrate thirtytwobit="true">
-                    <filelocation>https://ftp.mozilla.org/pub/firefox/releases/56.0.2/linux-i686/en-US/firefox-56.0.2.tar.bz2</filelocation>
-                    <hash>3808f8b852a20d748dd17cd69963f804bb1371ec</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-arm7hf.tar.gz</filelocation>
+                    <hash>1788cb6756d72c50ac2408e0dc60b778cb40f626</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -154,37 +126,37 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="2.37">
+            <version id="2.43">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.37/chromedriver_mac64.zip</filelocation>
-                    <hash>714e7abb1a7aeea9a8997b64a356a44fb48f5ef4</hash>
-                    <hashtype>sha1</hashtype>
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.43/chromedriver_mac64.zip</filelocation>
+                    <hash>249108ab937a3bf8ae8fd22366b1c208</hash>
+                    <hashtype>md5</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="operachromium">
-            <version id="2.35">
+            <version id="2.40">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.35/operadriver_mac64.zip</filelocation>
-                    <hash>66a88c856b55f6c89ff5d125760d920e0d4db6ff</hash>
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.40/operadriver_mac64.zip</filelocation>
+                    <hash>aae1d660f8004f2cdb97eb86f6fee197b91f1fd0</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="phantomjs">
-            <version id="1.9.8">
+            <version id="2.5.0">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-macosx.zip</filelocation>
-                    <hash>d70bbefd857f21104c5961b9dd081781cb4d999a</hash>
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.5.0-beta-macos.zip</filelocation>
+                    <hash>16acf892e286a4363a2b18fcecc347d95f0e3377</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
         </driver>
         <driver id="marionette">
-            <version id="0.20.0">
+            <version id="0.23.0">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-macos.tar.gz</filelocation>
-                    <hash>87a63f8adc2767332f2eadb24dedff982ac4f902</hash>
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-macos.tar.gz</filelocation>
+                    <hash>4340269571d26eea0242c0fc106097d0f4d4b059</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>


### PR DESCRIPTION
Update RepositoryMap with all libraries to the latest versions found today.
Some of hashtypes were changed into md5 because they are shown with md5 values in their download directories